### PR TITLE
feat(dashboard): /dashboard alias redirects to / (shareable URL for announcement)

### DIFF
--- a/web/src/routes/dashboard/+page.server.ts
+++ b/web/src/routes/dashboard/+page.server.ts
@@ -1,0 +1,9 @@
+import { redirect } from '@sveltejs/kit'
+import type { PageServerLoad } from './$types'
+
+// The real dashboard is the root page (/). This alias exists so people can
+// share https://cgpay-poc.commongood.earth/dashboard and land in the right
+// place, matching the PHP member site's /dashboard convention.
+export const load: PageServerLoad = () => {
+  redirect(302, '/')
+}


### PR DESCRIPTION
## Summary
- Adds `/dashboard` as an alias for the real dashboard at `/`.
- Currently `/dashboard` 404s (the dashboard is the home page after login). This adds a 302 redirect to `/`, so signed-in users land on their dashboard and signed-out users get bounced to `/login` by the existing root-page auth check.
