### PR TITLE
feat(web): move navy header into shared layout so all pages match commongood.earth

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -1,12 +1,95 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
+  import { goto } from '$app/navigation'
+  import { page } from '$app/state'
+  import { env } from '$env/dynamic/public'
+  import Brand from '$lib/components/Brand.svelte'
   import favicon from '$lib/assets/favicon.svg'
 
   let { children } = $props()
+
+  type UserInfo = { name?: string } | null
+  let userInfo = $state<UserInfo>(null)
+  let menu = $state<string[]>(['Dashboard', 'History', 'Community', 'Settings'])
+  let mounted = $state(false)
+
+  // Hide the app header on preview routes (they use their own layout + white-bg TopNav).
+  const isPreview = $derived(page.url.pathname.startsWith('/preview'))
+  const isLogin   = $derived(page.url.pathname.startsWith('/login'))
+  const showHeader = $derived(!isPreview)
+
+  const phpBase = env.PUBLIC_PHP_BASE_URL ?? ''
+  const PHP_PATH: Record<string, string> = {
+    Dashboard: '/dashboard', History: '/history', Community: '/community',
+    Settings: '/settings', Company: '/co', Admin: '/sadmin'
+  }
+  function menuHref(label: string): string {
+    if (!phpBase) return ''
+    return phpBase.replace(/\/$/, '') + (PHP_PATH[label] ?? `/${label.toLowerCase()}`)
+  }
+
+  const activeLabel = $derived.by(() => {
+    const p = page.url.pathname
+    if (p === '/') return 'Dashboard'
+    if (p.startsWith('/grants')) return 'Grants'
+    return ''
+  })
+
+  onMount(async () => {
+    mounted = true
+    const token = typeof localStorage !== 'undefined' ? localStorage.getItem('cg_token') : null
+    if (!token) return
+
+    const storedMenu = localStorage.getItem('cg_menu')
+    if (storedMenu) {
+      try {
+        const parsed = JSON.parse(storedMenu)
+        if (Array.isArray(parsed) && parsed.every(s => typeof s === 'string')) menu = parsed
+      } catch { /* ignore */ }
+    }
+
+    try {
+      const res = await fetch('/api/me/info?limit=1', {
+        headers: { authorization: `Bearer ${token}` }
+      })
+      if (res.ok) userInfo = await res.json()
+    } catch { /* header just shows Brand if fetch fails */ }
+  })
+
+  function signOut() {
+    localStorage.removeItem('cg_token')
+    localStorage.removeItem('cg_menu')
+    userInfo = null
+    goto('/login')
+  }
 </script>
 
 <svelte:head>
   <link rel="icon" href={favicon} />
 </svelte:head>
+
+{#if showHeader}
+  <nav class="topnav">
+    <Brand size={32} />
+    {#if userInfo && !isLogin}
+      <ul class="nav-links">
+        {#each menu as label}
+          {#if menuHref(label)}
+            <li><a class:active={label === activeLabel} href={label === 'Dashboard' ? '/' : menuHref(label)}>{label}</a></li>
+          {:else}
+            <li><button type="button" class="nav-disabled" title="Member site link not configured">{label}</button></li>
+          {/if}
+        {/each}
+      </ul>
+      <div class="account">
+        <span class="hi">Hi, {userInfo.name ?? ''}</span>
+        <button class="ghost" onclick={signOut}>Sign out</button>
+      </div>
+    {:else}
+      <div class="spacer"></div>
+    {/if}
+  </nav>
+{/if}
 
 {@render children()}
 
@@ -43,4 +126,56 @@
   :global(input) { font-family: inherit; }
   :global(a) { color: var(--cg-green); text-decoration: none; }
   :global(a:hover) { text-decoration: underline; }
+
+  .topnav {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    padding: 0.85rem 1.75rem;
+    background: var(--cg-navy);
+    color: var(--cg-on-navy);
+    border-bottom: none;
+  }
+  .nav-links {
+    list-style: none; padding: 0; margin: 0;
+    display: flex; gap: 1.5rem; flex: 1;
+  }
+  .nav-links a {
+    color: var(--cg-on-navy-muted);
+    font-size: 0.92rem;
+    font-weight: 500;
+    padding: 0.4rem 0.1rem;
+    border-bottom: 2px solid transparent;
+    text-decoration: none;
+  }
+  .nav-links a:hover { color: var(--cg-on-navy); text-decoration: none; }
+  .nav-links a.active { color: var(--cg-on-navy); border-bottom-color: var(--cg-green); }
+  .nav-disabled {
+    background: transparent;
+    border: none;
+    padding: 0.4rem 0.1rem;
+    color: var(--cg-on-navy-muted);
+    font-size: 0.92rem;
+    font-weight: 500;
+    opacity: 0.55;
+    cursor: not-allowed;
+    font-family: inherit;
+  }
+  .account {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  .hi { color: var(--cg-on-navy); font-size: 0.9rem; }
+  .ghost {
+    background: transparent;
+    color: var(--cg-on-navy);
+    border: 1px solid var(--cg-on-navy-muted);
+    border-radius: var(--cg-radius-sm);
+    padding: 0.35rem 0.85rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+  .ghost:hover { background: var(--cg-navy-soft); }
+  .spacer { flex: 1; }
 </style>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -2,14 +2,12 @@
   import { onMount } from 'svelte'
   import { goto } from '$app/navigation'
   import { env } from '$env/dynamic/public'
-  import Brand from '$lib/components/Brand.svelte'
   import Icon from '$lib/components/Icon.svelte'
   import type { InfoResponse, InfoTx } from './api/me/info/+server'
 
   let loading = $state(true)
   let error = $state<string | null>(null)
   let info = $state<InfoResponse | null>(null)
-  let menu = $state<string[]>(['Dashboard', 'History', 'Community', 'Settings'])
 
   type ModalKind = 'pay' | 'receive' | 'transfer' | 'soon' | null
   let modal = $state<ModalKind>(null)
@@ -18,22 +16,6 @@
   // Where the PHP member site lives. Menu items link to /<lowercased category> on this host.
   // Empty string = no PHP target configured; we render the menu as disabled.
   const phpBase = env.PUBLIC_PHP_BASE_URL ?? ''
-
-  // PHP top-level routes don't always match the menu label verbatim — these are
-  // the ones that diverge (Company → /co, Admin → /sadmin per cg-menu.inc).
-  const PHP_PATH: Record<string, string> = {
-    Dashboard: '/dashboard',
-    History: '/history',
-    Community: '/community',
-    Settings: '/settings',
-    Company: '/co',
-    Admin: '/sadmin'
-  }
-
-  function menuHref(label: string): string {
-    if (!phpBase) return ''
-    return phpBase.replace(/\/$/, '') + (PHP_PATH[label] ?? `/${label.toLowerCase()}`)
-  }
 
   // PHP URLs for the primary dashboard actions + footer placeholders. Until the
   // action flows are rebuilt in SvelteKit, clicking lands the (already-signed-in)
@@ -49,20 +31,12 @@
       await goto('/login')
       return
     }
-    const storedMenu = localStorage.getItem('cg_menu')
-    if (storedMenu) {
-      try {
-        const parsed = JSON.parse(storedMenu)
-        if (Array.isArray(parsed) && parsed.every(s => typeof s === 'string')) menu = parsed
-      } catch { /* ignore — fall back to default */ }
-    }
     try {
       const res = await fetch('/api/me/info?limit=20', {
         headers: { authorization: `Bearer ${token}` }
       })
       if (res.status === 401) {
         localStorage.removeItem('cg_token')
-        localStorage.removeItem('cg_menu')
         await goto('/login')
         return
       }
@@ -78,12 +52,6 @@
       loading = false
     }
   })
-
-  function signOut() {
-    localStorage.removeItem('cg_token')
-    localStorage.removeItem('cg_menu')
-    goto('/login')
-  }
 
   function fmtMoney(n: number) {
     return '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
@@ -134,27 +102,6 @@
 <svelte:window onkeydown={onKeydown} />
 
 <div class="page">
-  <nav class="topnav">
-    <Brand size={32} />
-    <ul class="nav-links">
-      {#each menu as label}
-        {#if label === 'Dashboard'}
-          <li><a class="active" href="/">Dashboard</a></li>
-        {:else if menuHref(label)}
-          <li><a href={menuHref(label)}>{label}</a></li>
-        {:else}
-          <li><button type="button" class="nav-disabled" title="Member site link not configured">{label}</button></li>
-        {/if}
-      {/each}
-    </ul>
-    {#if info}
-      <div class="account">
-        <span class="hi">Hi, {info.name}</span>
-        <button class="ghost" onclick={signOut}>Sign out</button>
-      </div>
-    {/if}
-  </nav>
-
   {#if loading}
     <main class="centered"><p class="state">Loading…</p></main>
   {:else if error}
@@ -394,50 +341,7 @@
 <style>
   .page { min-height: 100vh; display: flex; flex-direction: column; }
 
-  .topnav {
-    display: flex;
-    align-items: center;
-    gap: 2rem;
-    padding: 0.85rem 1.75rem;
-    background: var(--cg-navy);
-    color: var(--cg-on-navy);
-    border-bottom: none;
-  }
-  .nav-links {
-    list-style: none; padding: 0; margin: 0;
-    display: flex; gap: 1.5rem; flex: 1;
-  }
-  .nav-links a {
-    color: var(--cg-on-navy-muted);
-    font-size: 0.92rem;
-    font-weight: 500;
-    padding: 0.4rem 0.1rem;
-    border-bottom: 2px solid transparent;
-  }
-  .nav-links a:hover { color: var(--cg-on-navy); text-decoration: none; }
-  .nav-links a.active { color: var(--cg-on-navy); border-bottom-color: var(--cg-green); }
-  .nav-disabled {
-    background: transparent;
-    border: none;
-    padding: 0.4rem 0.1rem;
-    color: var(--cg-on-navy-muted);
-    font-size: 0.92rem;
-    font-weight: 500;
-    opacity: 0.55;
-    cursor: not-allowed;
-    font-family: inherit;
-  }
 
-  .account { display: flex; align-items: center; gap: 1rem; }
-  .hi { color: var(--cg-on-navy); font-size: 0.95rem; }
-  .ghost {
-    padding: 0.45rem 0.85rem;
-    background: transparent; color: var(--cg-on-navy);
-    border: 1px solid var(--cg-navy-soft); border-radius: var(--cg-radius-sm);
-    font-size: 0.9rem; cursor: pointer;
-    transition: background 0.15s, border-color 0.15s;
-  }
-  .ghost:hover { background: var(--cg-navy-soft); border-color: var(--cg-on-navy-muted); }
 
   .centered { flex: 1; display: grid; place-items: center; padding: 2rem 1.5rem; }
   .state { color: var(--cg-text-muted); }


### PR DESCRIPTION
## Summary

William noticed cgpay-poc pages don't consistently show the navy header bar that matches commongood.earth. The header was only rendered on the main dashboard `+page.svelte`. This PR pulls it into the shared root layout so **every** SvelteKit page (login, grants, deposits, etc.) gets the same navy bar at the top.

## What changed

- **`web/src/routes/+layout.svelte`** - now renders the navy `<nav class="topnav">` on every route (except `/preview/*`, which has its own layout + white-bg TopNav for design mockups):
  - Always shows the Common Good brand logo.
  - When authenticated (token in localStorage) AND not on the login page: shows menu links, "Hi, {name}", and Sign out button.
  - When on login page or unauthenticated: just brand + spacer.
- **`web/src/routes/+page.svelte`** - removed the duplicate topnav markup + styles + related state/imports (menu, menuHref, Brand, signOut, cg_menu localStorage plumbing). Dashboard just renders its main content now; header comes from layout.
- No visual change on preview routes (they use `preview/+layout.svelte` which is unchanged).