### PR TITLE
feat(web): match promo-site header color (#0946A6)

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -98,7 +98,7 @@
     --cg-green: #1e7a3a;
     --cg-green-hover: #155a2b;
     --cg-green-soft: rgba(30, 122, 58, 0.08);
-    --cg-navy: #0a2540;            /* matches the commongood.earth header */
+    --cg-navy: #0946A6;            /* matches the commongood.earth promo-site header */
     --cg-navy-soft: rgba(255, 255, 255, 0.1);
     --cg-bg: #f5f7f4;
     --cg-surface: #ffffff;


### PR DESCRIPTION
## Summary

Switch the SvelteKit navy header from `#0a2540` to `#0946A6` so cgpay-poc matches the commongood.earth promo site header.

