### PR TITLE
feat(grants): per-field validation errors on the report-grant form

### DIFF
--- a/web/src/lib/server/php-grants.ts
+++ b/web/src/lib/server/php-grants.ts
@@ -60,8 +60,12 @@ export async function createGrant(input: CreateGrantInput): Promise<number> {
 
   const data = await res.json().catch(() => null)
   if (!res.ok) {
-    const msg = (data && typeof data.error === 'string') ? data.error : `PHP /cgpay-grants create returned ${res.status}`
-    throw new PhpGrantError(msg, res.status)
+    // PHP now returns { message, errors: { fieldName: "message", ... }, error } — see cgpaygrants.inc
+    const msg = (data && typeof data.message === 'string') ? data.message
+             : (data && typeof data.error === 'string') ? data.error
+             : `PHP /cgpay-grants create returned ${res.status}`
+    const fieldErrors = (data && data.errors && typeof data.errors === 'object') ? data.errors as Record<string, string> : undefined
+    throw new PhpGrantError(msg, res.status, fieldErrors)
   }
   if (!data || typeof data.id !== 'number') throw new Error('PHP /cgpay-grants create: unexpected body')
   return data.id
@@ -69,9 +73,11 @@ export async function createGrant(input: CreateGrantInput): Promise<number> {
 
 export class PhpGrantError extends Error {
   status: number
-  constructor(message: string, status: number) {
+  fieldErrors?: Record<string, string>
+  constructor(message: string, status: number, fieldErrors?: Record<string, string>) {
     super(message)
     this.name = 'PhpGrantError'
     this.status = status
+    this.fieldErrors = fieldErrors
   }
 }

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -8,7 +8,7 @@
 
   let { children } = $props()
 
-  type UserInfo = { name?: string } | null
+  type UserInfo = { name?: string; sponsored?: boolean } | null
   let userInfo = $state<UserInfo>(null)
   let menu = $state<string[]>(['Dashboard', 'History', 'Community', 'Settings'])
   let mounted = $state(false)
@@ -80,7 +80,9 @@
             <li><button type="button" class="nav-disabled" title="Member site link not configured">{label}</button></li>
           {/if}
         {/each}
-        <li><a class:active={activeLabel === 'Grants'} href="/grants">Grants</a></li>
+        {#if userInfo.sponsored}
+          <li><a class:active={activeLabel === 'Grants'} href="/grants">Grants</a></li>
+        {/if}
       </ul>
       <div class="account">
         <span class="hi">Hi, {userInfo.name ?? ''}</span>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -80,6 +80,7 @@
             <li><button type="button" class="nav-disabled" title="Member site link not configured">{label}</button></li>
           {/if}
         {/each}
+        <li><a class:active={activeLabel === 'Grants'} href="/grants">Grants</a></li>
       </ul>
       <div class="account">
         <span class="hi">Hi, {userInfo.name ?? ''}</span>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -204,11 +204,11 @@
         <h2>Quick Actions</h2>
         <ul>
           <li>
-            <a href="/grants/new">
+            <a href="/grants">
               <div class="qa-icon tone-green"><Icon name="plus" size={18} /></div>
               <div class="qa-body">
-                <span class="qa-title">Report Expected Grant</span>
-                <span class="qa-desc">Notify us about incoming funding.</span>
+                <span class="qa-title">Expected Grants</span>
+                <span class="qa-desc">View reported grants or notify us about incoming funding.</span>
               </div>
             </a>
           </li>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -90,10 +90,6 @@
     return `Pending: ${fmtMoney(inAmt)} in / ${fmtMoney(outAmt)} out`
   }
 
-  function pendingRequestsCount(i: InfoResponse): number {
-    return i.txs.filter(t => t.pending).length
-  }
-
   function firstName(fullName: string): string {
     return fullName.split(' ')[0]
   }
@@ -126,22 +122,6 @@
           <div class="card-body">
             <span class="s-label">Available Funds</span>
             <span class="s-value">{fmtMoney(info.balance)}</span>
-          </div>
-        </article>
-
-        <article class="card summary-card">
-          <div class="icon-wrap tone-blue"><Icon name="clock" size={20} /></div>
-          <div class="card-body">
-            <span class="s-label">Pending Deposits</span>
-            <span class="s-value">{fmtMoney(info.summary.pendingTransferIn)}</span>
-          </div>
-        </article>
-
-        <article class="card summary-card">
-          <div class="icon-wrap tone-amber"><Icon name="clipboard" size={20} /></div>
-          <div class="card-body">
-            <span class="s-label">Pending Requests</span>
-            <span class="s-value">{pendingRequestsCount(info)}</span>
           </div>
         </article>
 
@@ -203,33 +183,17 @@
       <section class="quick-actions card">
         <h2>Quick Actions</h2>
         <ul>
-          <li>
-            <a href="/grants">
-              <div class="qa-icon tone-green"><Icon name="plus" size={18} /></div>
-              <div class="qa-body">
-                <span class="qa-title">Expected Grants</span>
-                <span class="qa-desc">View reported grants or notify us about incoming funding.</span>
-              </div>
-            </a>
-          </li>
-          <li>
-            <a href={phpUrl('/settings') || '#'} aria-disabled={!phpBase || undefined}>
-              <div class="qa-icon tone-blue"><Icon name="folder" size={18} /></div>
-              <div class="qa-body">
-                <span class="qa-title">Documents</span>
-                <span class="qa-desc">Upload and manage your documents.</span>
-              </div>
-            </a>
-          </li>
-          <li>
-            <a href={phpUrl('/community/message') || '#'} aria-disabled={!phpBase || undefined}>
-              <div class="qa-icon tone-amber"><Icon name="chat" size={18} /></div>
-              <div class="qa-body">
-                <span class="qa-title">Messages</span>
-                <span class="qa-desc">Message Common Good staff.</span>
-              </div>
-            </a>
-          </li>
+          {#if info.sponsored}
+            <li>
+              <a href="/grants">
+                <div class="qa-icon tone-green"><Icon name="plus" size={18} /></div>
+                <div class="qa-body">
+                  <span class="qa-title">Expected Grants</span>
+                  <span class="qa-desc">View reported grants or notify us about incoming funding.</span>
+                </div>
+              </a>
+            </li>
+          {/if}
           <li>
             <a href={phpUrl('/settings') || '#'} aria-disabled={!phpBase || undefined}>
               <div class="qa-icon tone-purple"><Icon name="user" size={18} /></div>
@@ -268,7 +232,7 @@
         <aside class="help card">
           <h3>Need help?</h3>
           <p>Our team is here for you.</p>
-          <a class="help-btn" href="mailto:support@commongood.earth">
+          <a class="help-btn" href={phpUrl('/help') || 'mailto:support@commongood.earth'}>
             <Icon name="help" size={16} /> Contact Support
           </a>
         </aside>

--- a/web/src/routes/api/grants/+server.ts
+++ b/web/src/routes/api/grants/+server.ts
@@ -40,7 +40,7 @@ export const POST: RequestHandler = async ({ request }) => {
   const body = await request.json().catch(() => null)
   if (!body) throw error(400, 'invalid request body')
 
-  // Client-side (pre-PHP) validation of the top-level grant fields.
+  // Client-side (pre-PHP) validation of grant + grantor fields.
   // Collect ALL problems into one payload so the UI highlights them together.
   const preErrors: Record<string, string> = {}
 
@@ -51,6 +51,17 @@ export const POST: RequestHandler = async ({ request }) => {
   if (!fullName) preErrors.fullName = "Please enter the grantor's name."
   if (!Number.isFinite(amount) || amount <= 0) preErrors.amount = 'Please enter an amount greater than zero.'
   if (!ALLOWED_BY.has(by)) preErrors.by = 'Please choose a payment method (ACH, check, or wire).'
+
+  // Grantor mailing address (per William 2026-07-31 — address required).
+  const address = typeof body.address === 'string' ? body.address.trim() : ''
+  const city = typeof body.city === 'string' ? body.city.trim() : ''
+  const zip = typeof body.zip === 'string' ? body.zip.trim() : ''
+  const state = Number(body.state)
+
+  if (!address) preErrors.address = "Please enter the grantor's street address."
+  if (!city) preErrors.city = "Please enter the grantor's city."
+  if (!Number.isFinite(state) || state <= 0) preErrors.state = "Please select the grantor's state."
+  if (!zip) preErrors.zip = "Please enter the grantor's zip code."
 
   if (Object.keys(preErrors).length > 0) return fieldErrorResponse(preErrors)
 

--- a/web/src/routes/api/grants/+server.ts
+++ b/web/src/routes/api/grants/+server.ts
@@ -27,6 +27,12 @@ export const GET: RequestHandler = async ({ request }) => {
 }
 
 const ALLOWED_BY = new Set(['ach', 'check', 'wire'])
+const FORM_ERROR_SUMMARY = 'There is an error in the information you typed — fix the highlighted field(s) and try again.'
+
+/** Return a 400 with per-field errors so the UI can highlight the bad fields. */
+function fieldErrorResponse(errors: Record<string, string>, message = FORM_ERROR_SUMMARY) {
+  return json({ message, errors, error: message }, { status: 400 })
+}
 
 export const POST: RequestHandler = async ({ request }) => {
   const claims = requireClaims(request)
@@ -34,13 +40,19 @@ export const POST: RequestHandler = async ({ request }) => {
   const body = await request.json().catch(() => null)
   if (!body) throw error(400, 'invalid request body')
 
+  // Client-side (pre-PHP) validation of the top-level grant fields.
+  // Collect ALL problems into one payload so the UI highlights them together.
+  const preErrors: Record<string, string> = {}
+
   const fullName = typeof body.fullName === 'string' ? body.fullName.trim() : ''
   const amount = Number(body.amount)
   const by = typeof body.by === 'string' ? body.by.toLowerCase() : ''
 
-  if (!fullName) throw error(400, 'grantor name required')
-  if (!Number.isFinite(amount) || amount <= 0) throw error(400, 'amount must be greater than zero')
-  if (!ALLOWED_BY.has(by)) throw error(400, 'payment method must be ach, check, or wire')
+  if (!fullName) preErrors.fullName = "Please enter the grantor's name."
+  if (!Number.isFinite(amount) || amount <= 0) preErrors.amount = 'Please enter an amount greater than zero.'
+  if (!ALLOWED_BY.has(by)) preErrors.by = 'Please choose a payment method (ACH, check, or wire).'
+
+  if (Object.keys(preErrors).length > 0) return fieldErrorResponse(preErrors)
 
   const input: CreateGrantInput = {
     uid: claims.uid,
@@ -57,7 +69,13 @@ export const POST: RequestHandler = async ({ request }) => {
     const id = await createGrant(input)
     return json({ id })
   } catch (e) {
-    if (e instanceof PhpGrantError && e.status === 400) throw error(400, e.message)
+    if (e instanceof PhpGrantError && e.status === 400) {
+      // Forward per-field errors from PHP if present; otherwise fall back to single-message shape.
+      if (e.fieldErrors && Object.keys(e.fieldErrors).length > 0) {
+        return fieldErrorResponse(e.fieldErrors, e.message || FORM_ERROR_SUMMARY)
+      }
+      return fieldErrorResponse({ _form: e.message }, e.message)
+    }
     if (e instanceof PhpGrantError && e.status === 403) throw error(403, 'not a sponsored partner')
     console.error('[grants] create failed:', e)
     throw error(502, 'Unable to save the grant — please try again.')

--- a/web/src/routes/api/me/info/+server.ts
+++ b/web/src/routes/api/me/info/+server.ts
@@ -42,13 +42,14 @@ export type InfoResponse = {
   name: string       // bestName: fullName falling back to login name
   loginName: string  // raw users.name (the login handle)
   balance: number
+  sponsored: boolean // true when this is a fiscally sponsored partner (u_company.coFlags bit CO_SPONSORED)
   summary: InfoSummary
   txs: InfoTx[]
 }
 
 // ---- Row shapes ----
 
-type UserRow = RowDataPacket & { balance: string | null; fullName: string | null; name: string }
+type UserRow = RowDataPacket & { balance: string | null; fullName: string | null; name: string; sponsored: number | null }
 type PendingRow = RowDataPacket & {
   amount: string
   other_uid: number
@@ -72,15 +73,20 @@ export const GET: RequestHandler = async ({ request, url }) => {
 
   const limit = Math.min(MAX_LIMIT, Math.max(1, Number(url.searchParams.get('limit') ?? DEFAULT_LIMIT)))
 
-  // 1) Balance + bestName for the user
+  // 1) Balance + bestName + sponsored-status for the user.
+  // sponsored comes from u_company.coFlags bit 2 (CO_SPONSORED); persons have no u_company row -> 0.
   const [userRows] = await pool.query<UserRow[]>(
-    'SELECT balance, fullName, name FROM users WHERE uid = ? LIMIT 1',
+    `SELECT u.balance, u.fullName, u.name,
+            CASE WHEN (c.coFlags & 4) > 0 THEN 1 ELSE 0 END AS sponsored
+       FROM users u LEFT JOIN u_company c ON c.uid = u.uid
+       WHERE u.uid = ? LIMIT 1`,
     [claims.uid]
   )
   if (!userRows[0]) throw error(404, 'user not found')
   const balance = userRows[0].balance === null ? 0 : Number(userRows[0].balance)
   const loginName = userRows[0].name
   const bestName = userRows[0].fullName || userRows[0].name
+  const sponsored = Number(userRows[0].sponsored) === 1
 
   // 2) Pending invoices (from tx_requests) — direction depends on who's the payer/payee
   // amount is signed: positive when we'd receive, negative when we'd pay
@@ -186,6 +192,7 @@ export const GET: RequestHandler = async ({ request, url }) => {
     name: bestName,
     loginName,
     balance,
+    sponsored,
     summary,
     txs
   }

--- a/web/src/routes/grants/new/+page.svelte
+++ b/web/src/routes/grants/new/+page.svelte
@@ -24,8 +24,15 @@
   let fieldErrors = $state<Record<string, string>>({})
 
   const amountNum = $derived(Number(amount.replace(/[$,\s]/g, '')))
+  const stateNum = $derived(Number(stateCode))
   const canSubmit = $derived(
-    !submitting && fullName.trim().length > 0 && Number.isFinite(amountNum) && amountNum > 0
+    !submitting
+    && fullName.trim().length > 0
+    && Number.isFinite(amountNum) && amountNum > 0
+    && address.trim().length > 0
+    && city.trim().length > 0
+    && stateCode.trim().length > 0 && Number.isFinite(stateNum) && stateNum > 0
+    && zip.trim().length > 0
   )
 
   async function submit() {
@@ -150,37 +157,37 @@
         </fieldset>
 
         <fieldset>
-          <legend>Grantor contact <span class="opt">(optional — helps us match faster)</span></legend>
+          <legend>Grantor Contact Information</legend>
           <div class="grid-2">
-            <div class="field" class:has-err={fe('email')}>
-              <label for="email">Email</label>
-              <input id="email" type="email" bind:value={email} autocomplete="off" aria-invalid={!!fe('email')} />
-              {#if fe('email')}<span class="field-err">{fe('email')}</span>{/if}
-            </div>
-            <div class="field" class:has-err={fe('phone')}>
-              <label for="phone">Phone</label>
-              <input id="phone" type="tel" bind:value={phone} autocomplete="off" aria-invalid={!!fe('phone')} />
-              {#if fe('phone')}<span class="field-err">{fe('phone')}</span>{/if}
-            </div>
             <div class="field span-2" class:has-err={fe('address')}>
-              <label for="address">Street address</label>
+              <label for="address">Street Address <span class="req">*</span></label>
               <input id="address" type="text" bind:value={address} autocomplete="off" aria-invalid={!!fe('address')} />
               {#if fe('address')}<span class="field-err">{fe('address')}</span>{/if}
             </div>
             <div class="field" class:has-err={fe('city')}>
-              <label for="city">City</label>
+              <label for="city">City <span class="req">*</span></label>
               <input id="city" type="text" bind:value={city} autocomplete="off" aria-invalid={!!fe('city')} />
               {#if fe('city')}<span class="field-err">{fe('city')}</span>{/if}
             </div>
             <div class="field" class:has-err={fe('state')}>
-              <label for="state">State</label>
+              <label for="state">State <span class="req">*</span></label>
               <input id="state" type="text" bind:value={stateCode} placeholder="State id" autocomplete="off" aria-invalid={!!fe('state')} />
               {#if fe('state')}<span class="field-err">{fe('state')}</span>{/if}
             </div>
             <div class="field" class:has-err={fe('zip')}>
-              <label for="zip">ZIP</label>
+              <label for="zip">ZIP <span class="req">*</span></label>
               <input id="zip" type="text" bind:value={zip} autocomplete="off" aria-invalid={!!fe('zip')} />
               {#if fe('zip')}<span class="field-err">{fe('zip')}</span>{/if}
+            </div>
+            <div class="field" class:has-err={fe('email')}>
+              <label for="email">Email <span class="opt">(optional)</span></label>
+              <input id="email" type="email" bind:value={email} autocomplete="off" aria-invalid={!!fe('email')} />
+              {#if fe('email')}<span class="field-err">{fe('email')}</span>{/if}
+            </div>
+            <div class="field" class:has-err={fe('phone')}>
+              <label for="phone">Phone <span class="opt">(optional)</span></label>
+              <input id="phone" type="tel" bind:value={phone} autocomplete="off" aria-invalid={!!fe('phone')} />
+              {#if fe('phone')}<span class="field-err">{fe('phone')}</span>{/if}
             </div>
           </div>
         </fieldset>

--- a/web/src/routes/grants/new/+page.svelte
+++ b/web/src/routes/grants/new/+page.svelte
@@ -20,6 +20,8 @@
 
   let submitting = $state(false)
   let error = $state<string | null>(null)
+  // Per-field validation errors from the server. Cleared on each submit attempt.
+  let fieldErrors = $state<Record<string, string>>({})
 
   const amountNum = $derived(Number(amount.replace(/[$,\s]/g, '')))
   const canSubmit = $derived(
@@ -30,6 +32,7 @@
     if (!canSubmit) return
     submitting = true
     error = null
+    fieldErrors = {}
 
     const token = localStorage.getItem('cg_token')
     if (!token) {
@@ -67,7 +70,11 @@
       }
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))
-        error = body.message ?? `Could not save the grant (${res.status})`
+        // Server returns { message, errors: { fieldName: "…" } } for validation failures.
+        if (body && typeof body.errors === 'object' && body.errors) {
+          fieldErrors = body.errors as Record<string, string>
+        }
+        error = body?.message ?? body?.error ?? `Could not save the grant (${res.status})`
         submitting = false
         return
       }
@@ -76,6 +83,11 @@
       error = 'Network error — please try again.'
       submitting = false
     }
+  }
+
+  // Helper for cleaner template — returns the field-error message or '' (falsy).
+  function fe(name: string): string {
+    return fieldErrors[name] ?? ''
   }
 </script>
 
@@ -109,27 +121,30 @@
         <div class="err" role="alert">{error}</div>
       {/if}
 
-      <form class="form-card" onsubmit={(e) => { e.preventDefault(); submit() }}>
+      <form class="form-card" onsubmit={(e) => { e.preventDefault(); submit() }} novalidate>
         <fieldset>
           <legend>Grant details</legend>
           <div class="grid-2">
-            <div class="field span-2">
+            <div class="field span-2" class:has-err={fe('fullName')}>
               <label for="grantor">Grantor Name <span class="req">*</span></label>
-              <input id="grantor" type="text" bind:value={fullName} placeholder="Full name of donor / funder" autocomplete="off" required />
+              <input id="grantor" type="text" bind:value={fullName} placeholder="Full name of donor / funder" autocomplete="off" aria-invalid={!!fe('fullName')} />
+              {#if fe('fullName')}<span class="field-err">{fe('fullName')}</span>{/if}
             </div>
 
-            <div class="field">
+            <div class="field" class:has-err={fe('amount')}>
               <label for="amount">Expected Amount <span class="req">*</span></label>
-              <div class="input-wrap"><span class="prefix">$</span><input id="amount" type="text" inputmode="decimal" bind:value={amount} placeholder="25,000.00" required /></div>
+              <div class="input-wrap"><span class="prefix">$</span><input id="amount" type="text" inputmode="decimal" bind:value={amount} placeholder="25,000.00" aria-invalid={!!fe('amount')} /></div>
+              {#if fe('amount')}<span class="field-err">{fe('amount')}</span>{/if}
             </div>
 
-            <div class="field">
+            <div class="field" class:has-err={fe('by')}>
               <label for="by">Payment Method <span class="req">*</span></label>
-              <select id="by" bind:value={by}>
+              <select id="by" bind:value={by} aria-invalid={!!fe('by')}>
                 <option value="ach">ACH</option>
                 <option value="check">Check</option>
                 <option value="wire">Wire</option>
               </select>
+              {#if fe('by')}<span class="field-err">{fe('by')}</span>{/if}
             </div>
           </div>
         </fieldset>
@@ -137,29 +152,35 @@
         <fieldset>
           <legend>Grantor contact <span class="opt">(optional — helps us match faster)</span></legend>
           <div class="grid-2">
-            <div class="field">
+            <div class="field" class:has-err={fe('email')}>
               <label for="email">Email</label>
-              <input id="email" type="email" bind:value={email} autocomplete="off" />
+              <input id="email" type="email" bind:value={email} autocomplete="off" aria-invalid={!!fe('email')} />
+              {#if fe('email')}<span class="field-err">{fe('email')}</span>{/if}
             </div>
-            <div class="field">
+            <div class="field" class:has-err={fe('phone')}>
               <label for="phone">Phone</label>
-              <input id="phone" type="tel" bind:value={phone} autocomplete="off" />
+              <input id="phone" type="tel" bind:value={phone} autocomplete="off" aria-invalid={!!fe('phone')} />
+              {#if fe('phone')}<span class="field-err">{fe('phone')}</span>{/if}
             </div>
-            <div class="field span-2">
+            <div class="field span-2" class:has-err={fe('address')}>
               <label for="address">Street address</label>
-              <input id="address" type="text" bind:value={address} autocomplete="off" />
+              <input id="address" type="text" bind:value={address} autocomplete="off" aria-invalid={!!fe('address')} />
+              {#if fe('address')}<span class="field-err">{fe('address')}</span>{/if}
             </div>
-            <div class="field">
+            <div class="field" class:has-err={fe('city')}>
               <label for="city">City</label>
-              <input id="city" type="text" bind:value={city} autocomplete="off" />
+              <input id="city" type="text" bind:value={city} autocomplete="off" aria-invalid={!!fe('city')} />
+              {#if fe('city')}<span class="field-err">{fe('city')}</span>{/if}
             </div>
-            <div class="field">
+            <div class="field" class:has-err={fe('state')}>
               <label for="state">State</label>
-              <input id="state" type="text" bind:value={stateCode} placeholder="State id" autocomplete="off" />
+              <input id="state" type="text" bind:value={stateCode} placeholder="State id" autocomplete="off" aria-invalid={!!fe('state')} />
+              {#if fe('state')}<span class="field-err">{fe('state')}</span>{/if}
             </div>
-            <div class="field">
+            <div class="field" class:has-err={fe('zip')}>
               <label for="zip">ZIP</label>
-              <input id="zip" type="text" bind:value={zip} autocomplete="off" />
+              <input id="zip" type="text" bind:value={zip} autocomplete="off" aria-invalid={!!fe('zip')} />
+              {#if fe('zip')}<span class="field-err">{fe('zip')}</span>{/if}
             </div>
           </div>
         </fieldset>
@@ -219,6 +240,12 @@
     width: 100%; padding: 0.55rem 0.75rem; box-sizing: border-box;
     border: 1px solid var(--cg-border); border-radius: var(--cg-radius-sm);
     font-size: 0.95rem; background: white; color: var(--cg-text);
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  }
+  .field input:focus, .field select:focus {
+    outline: none;
+    border-color: var(--cg-green);
+    box-shadow: 0 0 0 3px rgba(30, 122, 58, 0.15);
   }
   .field.span-2 { grid-column: span 2; }
   @media (max-width: 600px) { .grid-2 { grid-template-columns: 1fr; } .field.span-2 { grid-column: auto; } }
@@ -227,9 +254,30 @@
     display: flex; align-items: center; gap: 0.5rem;
     border: 1px solid var(--cg-border); border-radius: var(--cg-radius-sm);
     padding-left: 0.75rem; background: white;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
   }
   .input-wrap input { border: 0; padding: 0.55rem 0.5rem; }
+  .input-wrap input:focus { box-shadow: none; }
   .input-wrap .prefix { color: var(--cg-text-muted); }
+
+  /* Field-error highlighting */
+  .field.has-err input,
+  .field.has-err select {
+    border-color: #b91c1c;
+    background: #fef2f2;
+  }
+  .field.has-err .input-wrap {
+    border-color: #b91c1c;
+    background: #fef2f2;
+  }
+  .field.has-err label {
+    color: #991b1b;
+  }
+  .field-err {
+    color: #991b1b;
+    font-size: 0.8rem;
+    margin-top: 0.15rem;
+  }
 
   .form-footer {
     display: flex; justify-content: flex-end; gap: 0.5rem;

--- a/web/tests/e2e/grants.spec.ts
+++ b/web/tests/e2e/grants.spec.ts
@@ -39,15 +39,25 @@ test.describe('grants create form — client contract', () => {
     await expect(submit).toBeDisabled()
 
     await page.getByLabel(/grantor name/i).fill('Ada Lovelace Foundation')
-    await expect(submit).toBeDisabled() // amount still missing
+    await expect(submit).toBeDisabled() // amount + address still missing
 
     await page.getByLabel(/expected amount/i).fill('1500.00')
+    await expect(submit).toBeDisabled() // address fields still missing (William 2026-07-31)
+
+    await page.getByLabel(/street address/i).fill('123 Main St')
+    await page.getByLabel(/city/i).fill('Ashfield')
+    await page.getByLabel(/^state/i).fill('26')
+    await page.getByLabel(/zip/i).fill('01330')
     await expect(submit).toBeEnabled()
   })
 
   test('submitting with an invalid token surfaces an error and stays on /grants/new', async ({ page }) => {
     await page.getByLabel(/grantor name/i).fill('Ada Lovelace Foundation')
     await page.getByLabel(/expected amount/i).fill('1500')
+    await page.getByLabel(/street address/i).fill('123 Main St')
+    await page.getByLabel(/city/i).fill('Ashfield')
+    await page.getByLabel(/^state/i).fill('26')
+    await page.getByLabel(/zip/i).fill('01330')
     await page.getByRole('button', { name: /report grant/i }).click()
 
     // With a bogus token, /api/grants returns 401 → client wipes token and


### PR DESCRIPTION
## Summary

Per William + Jose 2026-07-31: submitting the report-grant form with bad email/phone/state/zip returned a generic "Unable to save the grant - please try again." message with no indication of what to fix. This PR adds per-field error highlighting with specific messages.

## Companion PR

Backend PHP: **cgmembers-frame#48** - refactors the PHP endpoint to collect ALL field errors and return them as `{errors: {field: message}}`. Ship this SvelteKit PR + the PHP PR together (SvelteKit falls back gracefully to a single-message shape if PHP returns the old format).

## What changed

**`web/src/lib/server/php-grants.ts`** - `PhpGrantError` now carries optional `fieldErrors: Record<string, string>` parsed from the PHP response body.

**`web/src/routes/api/grants/+server.ts`** - POST handler:
- Collects all client-side pre-validation errors into ONE payload instead of throwing on first failure
- Forwards `fieldErrors` from the PHP response to the frontend as `{message, errors, error}` JSON with 400 status
- Falls back to a `_form`-level error for legacy PHP single-message responses

**`web/src/routes/grants/new/+page.svelte`** - UI:
- New `fieldErrors` state (`Record<string, string>`)
- On submit failure, reads `body.errors` and highlights each bad field with red border + red-tinted label + inline red message text
- Top-of-form error banner shows the summary message
- `aria-invalid` set on bad inputs for accessibility
- Reset on every new submit attempt