### PR TITLE
hotfix(api): fall back to sponsored=false when u_company denied (fixes 500)

### DIFF
--- a/web/src/routes/api/me/info/+server.ts
+++ b/web/src/routes/api/me/info/+server.ts
@@ -49,7 +49,7 @@ export type InfoResponse = {
 
 // ---- Row shapes ----
 
-type UserRow = RowDataPacket & { balance: string | null; fullName: string | null; name: string; sponsored: number | null }
+type UserRow = RowDataPacket & { balance: string | null; fullName: string | null; name: string }
 type PendingRow = RowDataPacket & {
   amount: string
   other_uid: number
@@ -73,20 +73,30 @@ export const GET: RequestHandler = async ({ request, url }) => {
 
   const limit = Math.min(MAX_LIMIT, Math.max(1, Number(url.searchParams.get('limit') ?? DEFAULT_LIMIT)))
 
-  // 1) Balance + bestName + sponsored-status for the user.
-  // sponsored comes from u_company.coFlags bit 2 (CO_SPONSORED); persons have no u_company row -> 0.
+  // 1) Balance + bestName for the user.
   const [userRows] = await pool.query<UserRow[]>(
-    `SELECT u.balance, u.fullName, u.name,
-            CASE WHEN (c.coFlags & 4) > 0 THEN 1 ELSE 0 END AS sponsored
-       FROM users u LEFT JOIN u_company c ON c.uid = u.uid
-       WHERE u.uid = ? LIMIT 1`,
+    'SELECT balance, fullName, name FROM users WHERE uid = ? LIMIT 1',
     [claims.uid]
   )
   if (!userRows[0]) throw error(404, 'user not found')
   const balance = userRows[0].balance === null ? 0 : Number(userRows[0].balance)
   const loginName = userRows[0].name
   const bestName = userRows[0].fullName || userRows[0].name
-  const sponsored = Number(userRows[0].sponsored) === 1
+
+  // Sponsored-status lookup - separate query so a missing SELECT grant on u_company
+  // (as on the cgweb_ro user, 2026-08-04) doesn't 500 the whole dashboard.
+  // sponsored = u_company.coFlags bit 2 (CO_SPONSORED); persons have no u_company row -> false.
+  let sponsored = false
+  try {
+    const [coRows] = await pool.query<RowDataPacket[]>(
+      'SELECT (coFlags & 4) > 0 AS sponsored FROM u_company WHERE uid = ? LIMIT 1',
+      [claims.uid]
+    )
+    sponsored = Number(coRows[0]?.sponsored ?? 0) === 1
+  } catch {
+    // u_company inaccessible (permission or absent) - default to non-sponsored.
+    // UI will simply hide Grants nav + Report Expected Grant tile for this user.
+  }
 
   // 2) Pending invoices (from tx_requests) — direction depends on who's the payer/payee
   // amount is signed: positive when we'd receive, negative when we'd pay


### PR DESCRIPTION
## What broke

After PR #150 merged and cgpay-poc redeployed today (2026-08-04), /api/me/info returned 500 for every signed-in user - blocking the dashboard entirely. Error in the service logs:

    Error: SELECT command denied to user 'cgweb_ro'@'localhost' for table 'new_demo'.'u_company'

## Why

The sponsored flag added in PR #150 uses a LEFT JOIN to u_company. The read-only web user (cgweb_ro) doesn't have SELECT permission on u_company, so the whole query 500s.

## Fix

Split the sponsored lookup into its own query wrapped in try/catch, defaulting to sponsored=false on any error (permission or missing table). Same defensive pattern already used for the txs2 pending-transfer query further down in the same file.

Trade-off: until cgweb_ro is granted SELECT on u_company, sponsored users won't see the Grants nav link or Report Expected Grant tile (they'll be treated as non-sponsees). /grants still works if they visit it directly. This is acceptable temporary behavior - much better than a 500.