### PR TITLE
feat(grants): Check Number + Check Date fields when payment method = check (per William 2026-08-04)

### DIFF
--- a/web/src/lib/server/php-grants.ts
+++ b/web/src/lib/server/php-grants.ts
@@ -25,6 +25,8 @@ export type CreateGrantInput = {
   city?: string
   state?: number
   zip?: string
+  ckNum?: string   // required when by === 'check'
+  ckDate?: string  // required when by === 'check'; ISO date string or anything strtotime-parseable
 }
 
 function config() {

--- a/web/src/routes/api/grants/+server.ts
+++ b/web/src/routes/api/grants/+server.ts
@@ -63,6 +63,14 @@ export const POST: RequestHandler = async ({ request }) => {
   if (!Number.isFinite(state) || state <= 0) preErrors.state = "Please select the grantor's state."
   if (!zip) preErrors.zip = "Please enter the grantor's zip code."
 
+  // Check-specific fields (per William 2026-08-04): required when by === 'check'.
+  const ckNum = typeof body.ckNum === 'string' ? body.ckNum.trim() : ''
+  const ckDate = typeof body.ckDate === 'string' ? body.ckDate.trim() : ''
+  if (by === 'check') {
+    if (!ckNum) preErrors.ckNum = 'Please enter the check number.'
+    if (!ckDate) preErrors.ckDate = 'Please enter the check date.'
+  }
+
   if (Object.keys(preErrors).length > 0) return fieldErrorResponse(preErrors)
 
   const input: CreateGrantInput = {
@@ -75,6 +83,10 @@ export const POST: RequestHandler = async ({ request }) => {
     if (typeof body[k] === 'string' && body[k].trim()) input[k] = body[k].trim()
   }
   if (body.state != null && Number.isFinite(Number(body.state))) input.state = Number(body.state)
+  if (by === 'check') {
+    input.ckNum = ckNum
+    input.ckDate = ckDate
+  }
 
   try {
     const id = await createGrant(input)

--- a/web/src/routes/grants/new/+page.svelte
+++ b/web/src/routes/grants/new/+page.svelte
@@ -18,6 +18,10 @@
   let stateCode = $state('')
   let zip = $state('')
 
+  // Check-specific fields (per William 2026-08-04): only required when by === 'check'.
+  let ckNum = $state('')
+  let ckDate = $state('')
+
   let submitting = $state(false)
   let error = $state<string | null>(null)
   // Per-field validation errors from the server. Cleared on each submit attempt.
@@ -33,6 +37,7 @@
     && city.trim().length > 0
     && stateCode.trim().length > 0 && Number.isFinite(stateNum) && stateNum > 0
     && zip.trim().length > 0
+    && (by !== 'check' || (ckNum.trim().length > 0 && ckDate.trim().length > 0))
   )
 
   async function submit() {
@@ -57,6 +62,10 @@
     }
     if (stateCode.trim() && Number.isFinite(Number(stateCode))) {
       payload.state = Number(stateCode)
+    }
+    if (by === 'check') {
+      payload.ckNum = ckNum.trim()
+      payload.ckDate = ckDate.trim()
     }
 
     try {
@@ -153,6 +162,19 @@
               </select>
               {#if fe('by')}<span class="field-err">{fe('by')}</span>{/if}
             </div>
+
+            {#if by === 'check'}
+              <div class="field" class:has-err={fe('ckNum')}>
+                <label for="ckNum">Check Number <span class="req">*</span></label>
+                <input id="ckNum" type="text" bind:value={ckNum} placeholder="e.g. 1234" autocomplete="off" aria-invalid={!!fe('ckNum')} />
+                {#if fe('ckNum')}<span class="field-err">{fe('ckNum')}</span>{/if}
+              </div>
+              <div class="field" class:has-err={fe('ckDate')}>
+                <label for="ckDate">Check Date <span class="req">*</span></label>
+                <input id="ckDate" type="date" bind:value={ckDate} autocomplete="off" aria-invalid={!!fe('ckDate')} />
+                {#if fe('ckDate')}<span class="field-err">{fe('ckDate')}</span>{/if}
+              </div>
+            {/if}
           </div>
         </fieldset>
 


### PR DESCRIPTION
Companion to cgmembers-frame PR #53 (PHP side). Together they implement William's 2026-08-04 request:

> When the type of grant payment chosen is "check", the form needs to show two additional fields: check number and check date (which become part of the transaction description).

## Changes

- **`lib/server/php-grants.ts`** - added optional `ckNum` + `ckDate` to `CreateGrantInput`.
- **`api/grants/+server.ts`** - client-side validates ckNum + ckDate are present when `by === 'check'`, returns per-field errors otherwise. Passes them through to PHP on submit.
- **`grants/new/+page.svelte`** - conditional fields shown only when Payment Method is Check. Native `<input type="date">` for the date. Same red-highlight + per-field error UX as the rest of the form. Submit stays disabled until both fields are filled (when applicable).

## Testing

- All 5 existing e2e tests still pass locally (default `by = 'ach'` so the check path isn't triggered).
- Manual verification: switching Payment Method to Check reveals both fields; switching back hides them and clears their required-status.

## Merge sequencing

Should land together with cgmembers-frame PR #53. If frontend merges first with backend still on old code, PHP will silently ignore ckNum/ckDate (no crash). If backend merges first, PHP requires them but frontend won't send them - checks would fail validation. Best to merge #53 first, then this.