### PR TITLE
fix(deploy): load .env into pay process via node --env-file

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -64,11 +64,29 @@ namespace :deploy do
         # with no PORT set, so the app fell back to its own hardcoded default
         # (3000) and collided with an unrelated process already on that port
         # (confirmed on dev/staging).
-        running = capture(:pm2, 'jlist', raise_on_non_zero_exit: false).include?('"name":"pay"')
-        if running
-          execute :pm2, 'reload pay --update-env', env: { PORT: fetch(:pay_port) }
+        #
+        # `--node-args="--env-file=..."` (Node 20.6+, we're on 20.20.2) tells the
+        # node process to load the shared .env at startup — pm2 doesn't do this
+        # itself, and SvelteKit's adapter-node doesn't either. Without it, the
+        # process comes up with only PORT in its env; DB_*, PHP_SSO_URL,
+        # JWT_SECRET, etc. are all undefined at runtime and every login 401s
+        # because phpLookup can't reach the SSO endpoint. (Confirmed on test
+        # before this fix.)
+        #
+        # pm2 stores node-args with the process on `start`, so subsequent
+        # reloads preserve them. To transition an existing process that was
+        # started WITHOUT --env-file, we detect the missing flag in the current
+        # jlist and force a delete + fresh start once; subsequent deploys go
+        # through the normal reload path.
+        env_file = shared_path.join('web/.env')
+        jlist = capture(:pm2, 'jlist', raise_on_non_zero_exit: false)
+        running = jlist.include?('"name":"pay"')
+        needs_fresh_start = !running || !jlist.include?("--env-file=#{env_file}")
+        if needs_fresh_start
+          execute :pm2, 'delete pay', raise_on_non_zero_exit: false if running
+          execute :pm2, %Q{start build/index.js --name pay --node-args="--env-file=#{env_file}"}, env: { PORT: fetch(:pay_port) }
         else
-          execute :pm2, "start build/index.js --name pay", env: { PORT: fetch(:pay_port) }
+          execute :pm2, 'reload pay --update-env', env: { PORT: fetch(:pay_port) }
         end
       end
     end


### PR DESCRIPTION
## What broke

After yesterday's `cap test deploy` to pay-test.commongood.earth, every login 401'd with "Invalid account ID or password" - even with the correct password William confirmed (`abeone` / `k`). Diagnosed layer by layer:

- PHP `/cgpay-lookup` returned the right uid for abeone
- The test DB had abeone with a valid `$S$D...` hash
- `user_check_password("k", $row)` in PHP against that hash returned MATCH
- SvelteKit's `checkPassword()` port against the same hash + "k" also returned true

Everything worked in isolation, but /api/login always 401'd. Then I checked the actual env of the running pay process - only `PORT=3001` was set. All other config from the shared `.env` was undefined at runtime, so `phpLookup()` bailed immediately at `if (!ssoUrl || !secret) return null`, user ended up undefined, checkPassword fell through to DUMMY_HASH, every attempt 401'd.

## Root cause

pm2 doesn't auto-load `.env` files, and SvelteKit's adapter-node doesn't either. Capistrano's `linked_files: %w[web/.env]` correctly symlinks the shared `.env` into the release, but nothing reads it into `process.env` on process start.

## Fix

Pass `--node-args="--env-file=/home/<stage>/pay/shared/web/.env"` to `pm2 start`. Node 20.6+ (we're on 20.20.2) loads the file into `process.env` before the app starts, so `$env/dynamic/private` picks up the right values.

pm2 stores node-args with the process on `start`, so subsequent reloads preserve them. To transition an existing process that was started WITHOUT `--env-file`, the task detects the missing flag in the current jlist and forces a delete + fresh start once; subsequent deploys go through the normal reload path.

## Verification

Manually sourced `.env` into pm2 env on test yesterday to prove the theory works. Login flow returned a valid JWT + user info, browser sign-in as `abeone` / `k` works.

After this PR merges + you re-run `cap test deploy`, the fresh-start branch fires once, and the fix is durable across future deploys.