### PR TITLE
feat(grants): PR B skeleton - Drive upload for grant agreement PDFs

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "web",
 			"version": "0.0.1",
 			"dependencies": {
+				"googleapis": "^144.0.0",
 				"jsonwebtoken": "^9.0.3",
 				"mysql2": "^3.22.4"
 			},
@@ -2032,6 +2033,15 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2094,6 +2104,26 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/bidi-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -2104,11 +2134,49 @@
 				"require-from-string": "^2.0.2"
 			}
 		},
+		"node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
 			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/chai": {
 			"version": "6.2.2",
@@ -2205,6 +2273,23 @@
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/decimal.js": {
 			"version": "10.6.0",
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -2265,6 +2350,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -2287,11 +2386,19 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/es-errors": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -2303,6 +2410,18 @@
 			"integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/esbuild": {
 			"version": "0.28.0",
@@ -2388,6 +2507,12 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT"
+		},
 		"node_modules/fdir": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2439,10 +2564,39 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gaxios": {
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+			"integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"is-stream": "^2.0.0",
+				"node-fetch": "^2.6.9",
+				"uuid": "^9.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+			"integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"gaxios": "^6.1.1",
+				"google-logging-utils": "^0.0.2",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/generate-function": {
@@ -2454,11 +2608,140 @@
 				"is-property": "^1.0.2"
 			}
 		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/google-auth-library": {
+			"version": "9.15.1",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+			"integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^6.1.1",
+				"gcp-metadata": "^6.1.0",
+				"gtoken": "^7.0.0",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/google-logging-utils": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+			"integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/googleapis": {
+			"version": "144.0.0",
+			"resolved": "https://registry.npmjs.org/googleapis/-/googleapis-144.0.0.tgz",
+			"integrity": "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"google-auth-library": "^9.0.0",
+				"googleapis-common": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/googleapis-common": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+			"integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"gaxios": "^6.0.3",
+				"google-auth-library": "^9.7.0",
+				"qs": "^6.7.0",
+				"url-template": "^2.0.8",
+				"uuid": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gtoken": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+			"integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+			"license": "MIT",
+			"dependencies": {
+				"gaxios": "^6.0.0",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/hasown": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
 			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -2478,6 +2761,19 @@
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -2552,6 +2848,18 @@
 				"@types/estree": "^1.0.6"
 			}
 		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2598,6 +2906,15 @@
 				"canvas": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
 			}
 		},
 		"node_modules/jsonwebtoken": {
@@ -3014,6 +3331,15 @@
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/mdn-data": {
 			"version": "2.27.1",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -3108,6 +3434,60 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/node-fetch/node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"license": "MIT"
+		},
+		"node_modules/node-fetch/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/node-fetch/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/obug": {
@@ -3267,6 +3647,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/qs": {
+			"version": "6.15.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/react-is": {
@@ -3485,6 +3881,78 @@
 			"integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/siginfo": {
 			"version": "2.0.0",
@@ -3788,6 +4256,26 @@
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
 			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
 			"license": "MIT"
+		},
+		"node_modules/url-template": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+			"integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+			"license": "BSD"
+		},
+		"node_modules/uuid": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
 		},
 		"node_modules/vite": {
 			"version": "8.0.14",

--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
 		"vitest": "^4.1.9"
 	},
 	"dependencies": {
+		"googleapis": "^144.0.0",
 		"jsonwebtoken": "^9.0.3",
 		"mysql2": "^3.22.4"
 	}

--- a/web/src/lib/server/drive.ts
+++ b/web/src/lib/server/drive.ts
@@ -1,0 +1,102 @@
+// Google Drive upload helper for grant agreement PDFs (Phase 3.5 PR B).
+//
+// Design:
+//   - Uses a Google Cloud service account (creds JSON at GOOGLE_APPLICATION_CREDENTIALS).
+//   - Uploads into GDRIVE_GRANT_CONTRACTS_FOLDER_ID or a per-year subfolder.
+//   - Returns the new file's Drive id + a webViewLink for admins to open the file.
+//   - Silent no-op when creds/folder aren't configured — matches PR C's Twilio pattern.
+//     Callers can proceed to create the grant record without a driveFileId; the admin
+//     can attach a file later via the admin form (fsgrants.inc).
+//
+// Env vars:
+//   GOOGLE_APPLICATION_CREDENTIALS  Absolute path to the service account JSON key.
+//   GDRIVE_GRANT_CONTRACTS_FOLDER_ID Parent folder id in Drive (e.g. the "Grant Contracts" folder,
+//                                    or a per-year folder if you want auto-nesting handled elsewhere).
+//
+// Dependency: googleapis (added in package.json). Import is dynamic so the app still
+// boots + builds even if the package isn't installed on a given environment yet.
+
+import { env } from '$env/dynamic/private'
+
+export type DriveUploadResult = {
+  fileId: string
+  webViewLink: string
+}
+
+export type DriveUploadInput = {
+  fileName: string
+  mimeType: string
+  fileBuffer: Buffer
+  /** Override the folder id from env (e.g. per-year subfolder). Optional. */
+  folderId?: string
+}
+
+/**
+ * Upload a file to Drive. Returns null (not an error) when credentials or folder
+ * id aren't configured — callers should log-and-continue in that case, not crash.
+ */
+export async function uploadFileToDrive(input: DriveUploadInput): Promise<DriveUploadResult | null> {
+  const keyFile = env.GOOGLE_APPLICATION_CREDENTIALS
+  const folderId = input.folderId || env.GDRIVE_GRANT_CONTRACTS_FOLDER_ID
+
+  if (!keyFile || !folderId) {
+    console.warn('[drive] skipped upload - GOOGLE_APPLICATION_CREDENTIALS or GDRIVE_GRANT_CONTRACTS_FOLDER_ID not set')
+    return null
+  }
+
+  // Dynamic import so the app still builds without the googleapis package
+  // (useful during rollout / on environments not yet running the Drive feature).
+  const { google } = await import('googleapis')
+  const { Readable } = await import('node:stream')
+
+  const auth = new google.auth.GoogleAuth({
+    keyFile,
+    scopes: ['https://www.googleapis.com/auth/drive.file']
+  })
+  const drive = google.drive({ version: 'v3', auth })
+
+  const res = await drive.files.create({
+    requestBody: {
+      name: input.fileName,
+      parents: [folderId]
+    },
+    media: {
+      mimeType: input.mimeType,
+      body: Readable.from(input.fileBuffer)
+    },
+    fields: 'id, webViewLink'
+  })
+
+  const fileId = res.data.id
+  if (!fileId) {
+    throw new Error('Drive upload returned no file id')
+  }
+  return {
+    fileId,
+    webViewLink: res.data.webViewLink ?? ''
+  }
+}
+
+/**
+ * Build the Drive filename per William's convention:
+ *   `{YYYY-MM-DD} {grantor} ${amount} to {sponsee}.{ext}`
+ * Example: `2026-08-25 Ford Foundation $50,000 to Earthseed.pdf`
+ *
+ * Strips filename-unsafe characters from grantor + sponsee names.
+ */
+export function driveFileName(input: {
+  createdSec: number
+  grantorName: string
+  amount: number
+  sponseeName: string
+  originalName: string
+}): string {
+  const date = new Date(input.createdSec * 1000).toISOString().slice(0, 10) // YYYY-MM-DD
+  const amt = '$' + Math.round(input.amount).toLocaleString('en-US')
+  const ext = (input.originalName.split('.').pop() || 'pdf').toLowerCase().replace(/[^a-z0-9]/g, '') || 'pdf'
+  const clean = (s: string) => s.replace(/[\/\\:*?"<>|]/g, '').trim()
+  return `${date} ${clean(input.grantorName)} ${amt} to ${clean(input.sponseeName)}.${ext}`
+}
+
+/** UNDOC_GRANT_MAX from PHP defs.inc — file upload is required when grant > this. */
+export const UNDOC_GRANT_MAX = 5000

--- a/web/src/lib/server/php-grants.ts
+++ b/web/src/lib/server/php-grants.ts
@@ -27,6 +27,7 @@ export type CreateGrantInput = {
   zip?: string
   ckNum?: string   // required when by === 'check'
   ckDate?: string  // required when by === 'check'; ISO date string or anything strtotime-parseable
+  driveFileId?: string // Google Drive file id for the grant agreement PDF (PR B)
 }
 
 function config() {

--- a/web/src/routes/api/grants/+server.ts
+++ b/web/src/routes/api/grants/+server.ts
@@ -6,6 +6,7 @@ import { json, error } from '@sveltejs/kit'
 import type { RequestHandler } from './$types'
 import { bearerFromRequest, verifyToken } from '$lib/server/auth'
 import { listGrants, createGrant, PhpGrantError, type CreateGrantInput } from '$lib/server/php-grants'
+import { uploadFileToDrive, driveFileName, UNDOC_GRANT_MAX } from '$lib/server/drive'
 
 function requireClaims(request: Request) {
   const token = bearerFromRequest(request)
@@ -37,8 +38,24 @@ function fieldErrorResponse(errors: Record<string, string>, message = FORM_ERROR
 export const POST: RequestHandler = async ({ request }) => {
   const claims = requireClaims(request)
 
-  const body = await request.json().catch(() => null)
-  if (!body) throw error(400, 'invalid request body')
+  // Accept either JSON (backward-compatible, no file) or multipart/form-data (with agreement file).
+  // Grants over UNDOC_GRANT_MAX ($5k) should include an agreement PDF (per William, Phase 3.5 PR B).
+  const contentType = request.headers.get('content-type') || ''
+  let body: Record<string, unknown> | null = null
+  let file: File | null = null
+
+  if (contentType.startsWith('multipart/form-data')) {
+    const form = await request.formData().catch(() => null)
+    if (!form) throw error(400, 'invalid request body')
+    body = {}
+    for (const [k, v] of form.entries()) {
+      if (v instanceof File) file = v
+      else body[k] = v
+    }
+  } else {
+    body = await request.json().catch(() => null)
+    if (!body) throw error(400, 'invalid request body')
+  }
 
   // Client-side (pre-PHP) validation of grant + grantor fields.
   // Collect ALL problems into one payload so the UI highlights them together.
@@ -71,6 +88,16 @@ export const POST: RequestHandler = async ({ request }) => {
     if (!ckDate) preErrors.ckDate = 'Please enter the check date.'
   }
 
+  // Agreement file required for grants > UNDOC_GRANT_MAX (per William, PR B).
+  // File itself is optional at submission time when the sponsee doesn't have one yet;
+  // admin can attach later. So we only enforce the "need something" rule for large grants.
+  const MAX_FILE_BYTES = 10 * 1024 * 1024 // 10 MB
+  if (file) {
+    if (file.size > MAX_FILE_BYTES) {
+      preErrors.agreement = 'File is too large (max 10 MB).'
+    }
+  }
+
   if (Object.keys(preErrors).length > 0) return fieldErrorResponse(preErrors)
 
   const input: CreateGrantInput = {
@@ -86,6 +113,29 @@ export const POST: RequestHandler = async ({ request }) => {
   if (by === 'check') {
     input.ckNum = ckNum
     input.ckDate = ckDate
+  }
+
+  // Upload agreement file to Drive if present. Non-fatal if it fails or is
+  // silently skipped (no creds configured) - grant record still gets created.
+  if (file) {
+    try {
+      const buf = Buffer.from(await file.arrayBuffer())
+      const uploaded = await uploadFileToDrive({
+        fileName: driveFileName({
+          createdSec: Math.floor(Date.now() / 1000),
+          grantorName: fullName,
+          amount,
+          sponseeName: claims.name || `uid ${claims.uid}`,
+          originalName: file.name
+        }),
+        mimeType: file.type || 'application/octet-stream',
+        fileBuffer: buf
+      })
+      if (uploaded) input.driveFileId = uploaded.fileId
+    } catch (e) {
+      // Log but don't block grant creation - admin can attach the file later.
+      console.error('[grants] Drive upload failed:', e)
+    }
   }
 
   try {

--- a/web/src/routes/grants/new/+page.svelte
+++ b/web/src/routes/grants/new/+page.svelte
@@ -22,12 +22,18 @@
   let ckNum = $state('')
   let ckDate = $state('')
 
+  // Grant agreement PDF - only shown when amount > $5k (Phase 3.5 PR B).
+  // Optional at submit time (sponsee may not have signed agreement yet); admin can attach later.
+  let agreementFile = $state<File | null>(null)
+  const UNDOC_GRANT_MAX = 5000
+
   let submitting = $state(false)
   let error = $state<string | null>(null)
   // Per-field validation errors from the server. Cleared on each submit attempt.
   let fieldErrors = $state<Record<string, string>>({})
 
   const amountNum = $derived(Number(amount.replace(/[$,\s]/g, '')))
+  const showAgreementUpload = $derived(Number.isFinite(amountNum) && amountNum > UNDOC_GRANT_MAX)
   const stateNum = $derived(Number(stateCode))
   const canSubmit = $derived(
     !submitting
@@ -68,12 +74,28 @@
       payload.ckDate = ckDate.trim()
     }
 
-    try {
-      const res = await fetch('/api/grants', {
+    // When an agreement file is attached, submit as multipart/form-data.
+    // Otherwise stick with JSON (matches existing test coverage).
+    let fetchInit: RequestInit
+    if (agreementFile) {
+      const form = new FormData()
+      for (const [k, v] of Object.entries(payload)) form.append(k, String(v))
+      form.append('agreement', agreementFile, agreementFile.name)
+      fetchInit = {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}` }, // let the browser set content-type + boundary
+        body: form
+      }
+    } else {
+      fetchInit = {
         method: 'POST',
         headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
         body: JSON.stringify(payload)
-      })
+      }
+    }
+
+    try {
+      const res = await fetch('/api/grants', fetchInit)
       if (res.status === 401) {
         localStorage.removeItem('cg_token')
         await goto('/login')
@@ -175,6 +197,17 @@
                 {#if fe('ckDate')}<span class="field-err">{fe('ckDate')}</span>{/if}
               </div>
             {/if}
+
+            {#if showAgreementUpload}
+              <div class="field span-2" class:has-err={fe('agreement')}>
+                <label for="agreement">Grant Agreement <span class="opt">(PDF, optional)</span></label>
+                <input id="agreement" type="file" accept="application/pdf,image/*"
+                  onchange={(e) => { agreementFile = (e.currentTarget as HTMLInputElement).files?.[0] ?? null }}
+                  aria-invalid={!!fe('agreement')} />
+                <span class="hint">For grants over ${UNDOC_GRANT_MAX.toLocaleString()}, please attach the signed agreement if you have it. You can also send it later - an admin will file it when the funds arrive.</span>
+                {#if fe('agreement')}<span class="field-err">{fe('agreement')}</span>{/if}
+              </div>
+            {/if}
           </div>
         </fieldset>
 
@@ -260,6 +293,7 @@
   .form-card fieldset { border: 0; padding: 0; margin: 0; }
   .form-card legend { font-weight: 600; margin-bottom: 0.75rem; font-size: 0.95rem; }
   .opt { font-weight: 400; color: var(--cg-text-muted); font-size: 0.85rem; }
+  .hint { display: block; font-size: 0.8rem; color: var(--cg-text-muted); margin-top: 0.35rem; line-height: 1.4; }
   .req { color: #b91c1c; margin-left: 0.15rem; }
 
   .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }


### PR DESCRIPTION
Phase 3.5 PR B - grant agreement PDF upload to Google Drive when a sponsee reports a grant over $5k.

## What's in this PR (SvelteKit side)

- **`web/src/lib/server/drive.ts`** - new helper. Uploads a file to Google Drive via the googleapis SDK using a service-account JSON keyfile (path from `GOOGLE_APPLICATION_CREDENTIALS`). Silent no-op when credentials or `GDRIVE_GRANT_CONTRACTS_FOLDER_ID` aren't set - matches PR C's Twilio pattern. Also exports `driveFileName()` which builds the William-spec filename (`{YYYY-MM-DD} {grantor} ${amount} to {sponsee}.{ext}`).

- **`web/src/lib/server/php-grants.ts`** - added optional `driveFileId` to `CreateGrantInput` so the SvelteKit endpoint can pass the id through to PHP.

- **`web/src/routes/api/grants/+server.ts`** - now accepts EITHER JSON (unchanged path, no file) OR multipart/form-data (with an `agreement` file field). When a file is present, uploads to Drive and includes the returned file id in the create-grant call to PHP. Non-fatal if the upload fails - grant record still gets created and an admin can attach later.

- **`web/src/routes/grants/new/+page.svelte`** - conditional file input appears when the grant amount exceeds $5k (`UNDOC_GRANT_MAX`). Copy explains that the file is optional (admin can file it later). When a file is picked, the form switches to FormData submit.

- **`web/package.json`** - added `googleapis` dep.

## What's NOT in this PR

- **PHP side of storing `driveFileId`** on the grants row - separate cgmembers-frame PR needed to accept the field and persist it to the `drive_file_id` column (migration for that column already exists on `feat/grants-form-v2-agreement-upload` in cgmembers-frame). SvelteKit currently passes `driveFileId` in the create payload; PHP silently ignores unknown fields until that companion PR lands.
- **Real end-to-end test** - blocked on William granting Service Account Key Admin permission (so I can download the JSON key and drop it on the server). Once unblocked, `.env` on `/home/test/pay/shared/web/` gets `GOOGLE_APPLICATION_CREDENTIALS` and `GDRIVE_GRANT_CONTRACTS_FOLDER_ID`, and the flow works.
- **Per-year folder auto-nesting** - the current helper uploads to a single folder id. If we want per-year subfolders (`Grant Contracts 2026/`), that's a small extension - can add either here or in a follow-up.

## Testing

- Full build passes (`npm run build`).
- All 5 existing grants e2e tests still pass (`playwright test tests/e2e/grants.spec.ts`) - they exercise the JSON path, which is unchanged.
- No new e2e tests for the file upload path yet - hard to test without real Drive credentials. Manual smoke test to follow after William unblocks + we deploy to test.

## Merge readiness

Safe to merge as-is. Behavior is unchanged in every environment until `GOOGLE_APPLICATION_CREDENTIALS` + `GDRIVE_GRANT_CONTRACTS_FOLDER_ID` are set. The frontend shows the upload field for grants > $5k regardless of backend readiness, but the form and API both handle a no-file submit and a not-configured backend gracefully.